### PR TITLE
Release: 2.10.8 – non-VPS publishing to DV - lower priority items

### DIFF
--- a/ckanext/datasetform/templates/package/read.html
+++ b/ckanext/datasetform/templates/package/read.html
@@ -6,9 +6,9 @@
     {{ form.errors(errors) }}
     {{ super() }}
 
-    {% snippet "package/snippets/data_publisher_notice.html", pkg_dict=pkg %}
-
-    {% set data = data if data else None %}
-    {% set errors = errors if errors else None %}
-    {% snippet "package/contact.html", pkg_id=pkg.id, pkg_name=pkg.name, userobj=c.userobj, data=data, errors=errors %}
+    {% block contact_info %}
+        {% set data = data if data else None %}
+        {% set errors = errors if errors else None %}
+        {% snippet "package/contact.html", pkg_id=pkg.id, pkg_name=pkg.name, userobj=c.userobj, data=data, errors=errors %}
+    {% endblock %}
 {% endblock %}

--- a/ckanext/datasetform/templates/package/read.html
+++ b/ckanext/datasetform/templates/package/read.html
@@ -5,6 +5,9 @@
 {% block primary_content_inner %}
     {{ form.errors(errors) }}
     {{ super() }}
+
+    {% snippet "package/snippets/data_publisher_notice.html", pkg_dict=pkg %}
+
     {% set data = data if data else None %}
     {% set errors = errors if errors else None %}
     {% snippet "package/contact.html", pkg_id=pkg.id, pkg_name=pkg.name, userobj=c.userobj, data=data, errors=errors %}

--- a/ckanext/datasetform/templates/package/snippets/data_publisher_notice.html
+++ b/ckanext/datasetform/templates/package/snippets/data_publisher_notice.html
@@ -1,0 +1,5 @@
+<section class="data-publisher-notice">
+  <p>
+    {{ _('Responsibility for legislative and policy compliance rests with the publisher.') }}
+  </p>
+</section>

--- a/ckanext/datasetform/templates/package/snippets/data_publisher_notice.html
+++ b/ckanext/datasetform/templates/package/snippets/data_publisher_notice.html
@@ -1,5 +1,0 @@
-<section class="data-publisher-notice">
-  <p>
-    {{ _('Responsibility for legislative and policy compliance rests with the publisher.') }}
-  </p>
-</section>


### PR DESCRIPTION
## Summary

### DATAVIC Tickets

**[DATAVIC-952](https://digital-vic.atlassian.net/browse/DATAVIC-952) — Add 'Data publisher' notice to all records**
- Wrapped `package/contact.html` render in `contact_info` block in `package/read.html` so the theme can override the contact section

[DATAVIC-952]: https://digital-vic.atlassian.net/browse/DATAVIC-952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ